### PR TITLE
Making url2png optional, dev server bug fix, and long type check for key id's

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -222,11 +222,10 @@ class Page(db.Model):
     @staticmethod
     def get_or_404(key):
         page = None
-        if isinstance(key, int) or (isinstance(key, basestring) and key.isdigit()):
+        if isinstance(key, long) or isinstance(key, int) or (isinstance(key, basestring) and key.isdigit()):
             page = Page.get_by_id(int(key))
         else:
             try:
-                key = str(key)
                 key_obj = db.Key(key)
             except BadKeyError:
                 abort(404)

--- a/app/models.py
+++ b/app/models.py
@@ -226,6 +226,7 @@ class Page(db.Model):
             page = Page.get_by_id(int(key))
         else:
             try:
+                key = str(key)
                 key_obj = db.Key(key)
             except BadKeyError:
                 abort(404)

--- a/app/tasks.py
+++ b/app/tasks.py
@@ -40,7 +40,7 @@ def stats_cron():
 @csrf_exempt
 def fetch_preview():
     page = Page.get_or_404(request.form.get('page_key', ''))
-    if 'localhost' in page.url or '127.0.0.1' in page.url:
+    if 'localhost' in page.url or '127.0.0.1' in page.url or use_url2png is False:
         return 'OK'
     url = 'http:' + url2png(page.url)
     result = urlfetch.fetch(url, deadline=10)

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -10,8 +10,8 @@ adjust_sys_path()
 if settings.debug:
     adjust_sys_path('ziplibs')
     # Enable ctypes for Jinja debugging
-    from google.appengine.tools.dev_appserver import HardenedModulesHook
-    HardenedModulesHook._WHITE_LIST_C_MODULES += ['_ctypes', 'gestalt']
+    # from google.appengine.tools.dev_appserver import HardenedModulesHook
+    # HardenedModulesHook._WHITE_LIST_C_MODULES += ['_ctypes', 'gestalt']
 else:
     adjust_sys_path(os.path.join('ziplibs.zip', 'ziplibs'))
 

--- a/settings.py
+++ b/settings.py
@@ -27,6 +27,7 @@ available_locales = [
 ]
 
 # API Keys for url2png.com
+use_url2png = False
 url2png = dict(
     user = 'USERNAME',
     password = 'PASSWORD',


### PR DESCRIPTION
Three changes on this pull request. One (the url2png one) is nice but not necessary, one is necessary for being able to run the current build on the current local GAE dev server, and one fixes a bug that makes it impossible to access the editor pages with the current version of GAE.
-  **Type check for a long in `models.py`** - I assume the version of GAE being used when the most recent WebPutty build was last updated used integers to store datastore entity keys. However, GAE seems to be using longs now, which causes _all_ the things to break. In the previous WebPutty version, it just checked for an int in `Page.get_or_404`, so all I did was add a check for a long as well.
- **Commented out importing `HardenedModulesHook` in `bootstrap.py`** - This was used to import ctypes for "Jinja debugging", according to the comments. I haven't been able to dig into the code enough yet to see exactly where that is being done in the debugging. However, as it stands that import breaks it when you're running it on a local dev server because Google is silly and they seem to have forgotten to change `simplejson` to `json` in the HardenedModulesHook module. I haven't run into any issues with commenting it out yet, but perhaps someone who knows the code can see what side effects will be caused by it? (If there is anything significant, it will ONLY be on the dev server, so that's good. I guess)
- **Making url2png optional** - The current WebPutty seems to expect that you are using url2png. I didn't want to use it, and I don't need the preview images it pulls, so I added a `use_url2png` variable. `tasks.py` now checks if that's set to True before starting the task that fetches the url2png images.

Hopefully somebody can take a look at these changes, and pull them in. The first two changes, at least, are necessary to getting it working under the current GAE version. It doesn't look like there's been much interest in WebPutty in the past year or so, which makes me sad! Is there someone at FogCreek currently maintaining the project?
